### PR TITLE
Add example tracking only configuration.

### DIFF
--- a/carla_spawn_objects/config/object_sensor_only.json
+++ b/carla_spawn_objects/config/object_sensor_only.json
@@ -1,0 +1,13 @@
+{   
+    "objects": 
+    [
+        {
+            "type": "sensor.pseudo.objects",
+            "id": "objects"
+        },
+        {
+            "type": "sensor.pseudo.actor_list",
+            "id": "actor_list"
+        }
+    ]
+}

--- a/carla_spawn_objects/setup.py
+++ b/carla_spawn_objects/setup.py
@@ -30,6 +30,8 @@ elif ROS_VERSION == 2:
             ('share/' + package_name, ['package.xml']),
             ('share/' + package_name + '/config',
              ['config/objects.json']),
+            ('share/' + package_name + '/config',
+             ['config/object_sensor_only.json']),
             (os.path.join('share', package_name), glob('launch/*.launch.py'))
         ],
         install_requires=['setuptools'],


### PR DESCRIPTION
Adds a config to report objects to ros-bridge without spawning anything.

Replaces the prior function of /tf which reported all vehicles on TF.